### PR TITLE
discord bot groundwork

### DIFF
--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -6,9 +6,9 @@ dependencies {
     compileOnly "com.comphenix.protocol:ProtocolLib:4.5.0"
 
     implementation project(":api")
-    /*implementation("net.dv8tion:JDA:4.2.0_227") {
+    implementation("net.dv8tion:JDA:5.0.0-alpha.12") {
         exclude module: "opus-java"
-    }*/
+    }
 
     // hikari
     implementation 'com.zaxxer:HikariCP:5.0.1'

--- a/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/ModuCore.kt
+++ b/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/ModuCore.kt
@@ -29,6 +29,8 @@ import dev.jaims.mcutils.bukkit.KotlinPlugin
 import dev.jaims.moducore.bukkit.api.DefaultModuCoreAPI
 import dev.jaims.moducore.bukkit.command.BaseCommand
 import dev.jaims.moducore.bukkit.command.allCommands
+import dev.jaims.moducore.bukkit.config.Modules
+import dev.jaims.moducore.bukkit.discord.ModuCoreDiscordBot
 import dev.jaims.moducore.bukkit.func.notifyVersion
 import dev.jaims.moducore.bukkit.func.serverStartTime
 import dev.jaims.moducore.bukkit.func.tps
@@ -64,9 +66,10 @@ class ModuCore : KotlinPlugin() {
         Metrics(this, bStatsId)
             .moduleMetric(this)
 
-        /*if (api.fileManager.modules[Modules.DISCORD_BOT]) {
-            // TODO
-        }*/
+        if (api.fileManager.modules[Modules.DISCORD_BOT]) {
+            // start discord bot
+            ModuCoreDiscordBot(this).start()
+        }
 
         // start tps
         server.scheduler.scheduleSyncRepeatingTask(this, tps, 100, 1)

--- a/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/config/FileManager.kt
+++ b/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/config/FileManager.kt
@@ -25,6 +25,7 @@
 package dev.jaims.moducore.bukkit.config
 
 import dev.jaims.moducore.bukkit.ModuCore
+import dev.jaims.moducore.bukkit.discord.config.DiscordBot
 import me.mattstudios.config.SettingsManager
 import java.io.File
 
@@ -58,7 +59,7 @@ class FileManager(private val plugin: ModuCore) {
     val warps = SettingsManager.from(warpsFile).configurationData(Warps::class.java).create()
 
     // discord
-    private val discordFile = File(plugin.dataFolder, "discord.yml")
+    private val discordFile = File(plugin.dataFolder, "discord/discord.yml")
     val discord = SettingsManager.from(discordFile).configurationData(DiscordBot::class.java).create()
 
     // all files

--- a/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/ModuCoreDiscordBot.kt
+++ b/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/ModuCoreDiscordBot.kt
@@ -1,0 +1,10 @@
+package dev.jaims.moducore.bukkit.discord
+
+import dev.jaims.moducore.bukkit.ModuCore
+
+class ModuCoreDiscordBot(val plugin: ModuCore) {
+
+    fun start() {
+
+    }
+}

--- a/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/commands/DiscordCommand.kt
+++ b/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/commands/DiscordCommand.kt
@@ -1,0 +1,10 @@
+package dev.jaims.moducore.bukkit.discord.commands
+
+import dev.jaims.moducore.bukkit.ModuCore
+import net.dv8tion.jda.api.interactions.commands.build.CommandData
+
+interface DiscordCommand {
+    val plugin: ModuCore
+    val name: String
+    val commandData: CommandData
+}

--- a/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/commands/SlashDiscordCommand.kt
+++ b/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/commands/SlashDiscordCommand.kt
@@ -1,0 +1,15 @@
+package dev.jaims.moducore.bukkit.discord.commands
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+
+abstract class SlashDiscordCommand : DiscordCommand, ListenerAdapter() {
+    abstract val description: String
+
+    abstract fun SlashCommandInteractionEvent.handle()
+
+    override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
+        if (name.lowercase() != event.name.lowercase()) return
+        event.handle()
+    }
+}

--- a/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/commands/link/LinkSlashDiscordCommand.kt
+++ b/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/commands/link/LinkSlashDiscordCommand.kt
@@ -1,0 +1,20 @@
+package dev.jaims.moducore.bukkit.discord.commands.link
+
+import dev.jaims.moducore.bukkit.ModuCore
+import dev.jaims.moducore.bukkit.discord.commands.SlashDiscordCommand
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.CommandData
+import net.dv8tion.jda.api.interactions.commands.build.Commands
+
+class LinkSlashDiscordCommand(override val plugin: ModuCore) : SlashDiscordCommand() {
+    override val name: String = "link"
+    override val description: String = "Link your Discord and Minecraft Accounts"
+    override val commandData: CommandData = Commands.slash(name, description)
+        .addOption(OptionType.STRING, "code", "The code that typing /link in Minecraft gives you.")
+
+    override fun SlashCommandInteractionEvent.handle() {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/config/DiscordBot.kt
+++ b/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/config/DiscordBot.kt
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package dev.jaims.moducore.bukkit.config
+package dev.jaims.moducore.bukkit.discord.config
 
 import me.mattstudios.config.SettingsHolder
 import me.mattstudios.config.annotations.Comment
@@ -52,5 +52,6 @@ object DiscordBot : SettingsHolder {
     @Comment("Leave this as blank if you don't want some certain updates sent to your admin discord channel.")
     @Path("channels.admin_id")
     val CHANNEL_ADMIN = Property.create("")
+
 
 }

--- a/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/data/ConfigurableEmbed.kt
+++ b/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/data/ConfigurableEmbed.kt
@@ -1,0 +1,31 @@
+package dev.jaims.moducore.bukkit.discord.data
+
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.bukkit.Bukkit
+import java.awt.Color
+
+data class ConfigurableEmbed(
+    val title: String?,
+    val color: String?,
+    val description: String?,
+    val fields: MutableList<ConfigurableEmbedField>
+) {
+    val asMessageEmbed: MessageEmbed
+        get() = EmbedBuilder()
+            .setTitle(title)
+            .setDescription(description)
+            .setColor(
+                color?.let {
+                    Color.getColor(it) ?: try {
+                        Color.decode(it)
+                    } catch (ignored: Throwable) {
+                        Bukkit.getLogger().warning("Color: $color is invalid for discord embed colors!")
+                        null
+                    }
+                }
+            )
+            // add fields
+            .apply { this@ConfigurableEmbed.fields.forEach { addField(it.asMessageEmbedField) } }
+            .build()
+}

--- a/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/data/ConfigurableEmbedField.kt
+++ b/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/data/ConfigurableEmbedField.kt
@@ -1,0 +1,13 @@
+package dev.jaims.moducore.bukkit.discord.data
+
+import net.dv8tion.jda.api.entities.MessageEmbed
+
+
+data class ConfigurableEmbedField(
+    val name: String,
+    val value: String,
+    val inline: Boolean
+) {
+    val asMessageEmbedField: MessageEmbed.Field
+        get() = MessageEmbed.Field(name, value, inline)
+}

--- a/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/data/ConfigurableMessage.kt
+++ b/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/discord/data/ConfigurableMessage.kt
@@ -1,0 +1,18 @@
+package dev.jaims.moducore.bukkit.discord.data
+
+import net.dv8tion.jda.api.MessageBuilder
+import net.dv8tion.jda.api.entities.Message
+
+data class ConfigurableMessage(
+    val embeded: Boolean = true,
+    val content: String? = null,
+    val embeds: MutableList<ConfigurableEmbed>
+) {
+
+    val asDiscordMessage: Message
+        get() = MessageBuilder()
+            .setContent(content)
+            .apply { if (embeded) setEmbeds(embeds.map { it.asMessageEmbed }) }
+            .build()
+
+}


### PR DESCRIPTION
## Checks
- [ ] `/moducoredump` command works without error
  - If you push a change that breaks the dump command, it is hard to debug issues if people have them.


## Description
Resolves #16.
- adds the ability to link discord account and Minecraft account
- this lets discord & Minecraft interact with each other a bit more