### PR TITLE
fix chat ping

### DIFF
--- a/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/listener/PlayerChatListener.kt
+++ b/bukkit/src/main/kotlin/dev/jaims/moducore/bukkit/listener/PlayerChatListener.kt
@@ -74,7 +74,7 @@ class PlayerChatListener(private val plugin: ModuCore) : Listener {
         // chat ping for all online players
         val mentionedPlayers = mutableSetOf<Player>()
         Bukkit.getOnlinePlayers().forEach {
-            if (message.contains(fileManager.config[Config.CHATPING_ACTIVATOR].colorize(player))) {
+            if (message.contains(fileManager.config[Config.CHATPING_ACTIVATOR].colorize(it))) {
                 message = message.replace(
                     fileManager.config[Config.CHATPING_ACTIVATOR].colorize(it),
                     fileManager.config[Config.CHATPING_FORMAT].colorize(it)


### PR DESCRIPTION
## Checks
- [x] `/moducoredump` command works without error
  - If you push a change that breaks the dump command, it is hard to debug issues if people have them.


## Description
Resolves #82 

It was only checking the player who sent the message every time, this updates so it checks every message for *all* online players.